### PR TITLE
Use fully-qualified dest path in get_url

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -45,7 +45,7 @@
 - name: PROMETHEUS | Download package
   get_url:
     url: "{{ prometheus_url }}"
-    dest: /tmp
+    dest: "/tmp/{{ prometheus_package }}"
   when: 'prometheus_force_reinstall or prometheus_check|failed or "prometheus, version {{ prometheus_version }}" not in prometheus_check.stderr'
 
 - name: PROMETHEUS | Extract package


### PR DESCRIPTION
Fixes the file ending up with an unknown filename after following redirects, etc.

**N.B. To keep the tree clean you may want to cherry-pick this commit rather than merge.**