### PR TITLE
Set regex specific to start and end of line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prometheus_server-role/tree/develop)
+### Fixed
+- *Prevent configuration verification from deleting config files* @edwinkortman
 
 ## [1.4.0](https://github.com/idealista/prometheus_server-role/tree/1.4.0)
 [Full Changelog](https://github.com/idealista/prometheus_server-role/compare/1.3.1...1.4.0)

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -93,7 +93,7 @@
 
 - name: PROMETHEUS | Set scrapes templates var
   set_fact:
-    prometheus_scrapes_templates:  "{{ scrapes_loaded.files | map(attribute='path') | map('basename') | map('splitext') | map('first') | map('regex_replace', '(.*)', '2_\\1') |  list | union(['1_global_prometheus']) }}"
+    prometheus_scrapes_templates:  "{{ scrapes_loaded.files | map(attribute='path') | map('basename') | map('splitext') | map('first') | map('regex_replace', '^(.*)$', '2_\\1') |  list | union(['1_global_prometheus']) }}"
 
 - name: PROMETHEUS | List all scrapes in path
   find:


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Before this change running this role on a Python3 environment results in configuration for scrape targets being deleted. What happened was that configuration files are being created as `2_node` and the verification if they should be deleted checks on `2_node2_`. Somehow the regex matched on the start and end of the string. By making it explicit as in the commit it no longer adds the `2_` to the end and thus prevents the config from being deleted. This change has been tested on Python2 and it did not cause any issues.

### Benefits

Configuration files not being deleted on a Python3 environment.

### Possible Drawbacks

None. 

### Applicable Issues

None.
