### PR TITLE
[BUG] Change prometheus user shell path in /etc/passwd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
 script:
   - export DOCKER_BASE_IMAGE=${DOCKER_BASE_IMAGE}
   - pipenv run molecule test
-
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/
   email:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Changed
 ### Removed
 
+### Added
+- [#53](https://github.com/idealista/prometheus_server_role/issues/53) *[BUG] Change prometheus user shell path in /etc/passwd* @marcelogalmor
+
 ## [1.10.0](https://github.com/idealista/prometheus_server_role/tree/1.10.0)
 ## [Full Changelog](https://github.com/idealista/prometheus_server_role/compare/1.9.0...1.10.0)
 ### Added

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ prometheus_config_validation: true
 # Owner
 prometheus_user: prometheus
 prometheus_group: prometheus
+prometheus_user_shell: /usr/sbin/nologin
 
 # start on boot
 prometheus_service_enabled: True

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,7 +15,7 @@
     name: "{{ prometheus_user }}"
     group: "{{ prometheus_group }}"
     system: yes
-    shell: /usr/sbin/nologin
+    shell: "{{ prometheus_user_shell }}"
     createhome: no
 
 - name: PROMETHEUS | Ensure skeleton paths

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,7 +15,7 @@
     name: "{{ prometheus_user }}"
     group: "{{ prometheus_group }}"
     system: yes
-    shell: /sbin/nologin
+    shell: /usr/sbin/nologin
     createhome: no
 
 - name: PROMETHEUS | Ensure skeleton paths


### PR DESCRIPTION
<!--
PREREQUISITES

Have you read Idealista's Code of Conduct? By filling an Issue, you are expected to comply with it,
 including treating everyone with respect: https://github.com/idealista/idealista/blob/master/CODE_OF_CONDUCT.md

Check that your issue isn't already filled: https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Aidealista

Check that there is not already provided the described functionality
-->

### Description

To solve the idempotency of abv-monitor-playbook it is necessary to match the path of the prometheus user shell as the rest of the roles on which it depends:

* Change /sbin/nologin to /usr/sbin/nologin and set it as a variable.

### Why is this needed?

So the role is updated along all the roles

### Additional Information

N/A
