### PR TITLE
#56 Stop using reload handler in favor of the restart one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Removed
 
 ### Fixed
-- [#56](https://github.com/idealista/prometheus_server_role/issues/56) *Stop using reload handler in favour of the restart one* @caldito
+- [#56](https://github.com/idealista/prometheus_server_role/issues/56) *Stop using reload handler in favor of the restart one* @caldito
 ### Added
 - [#53](https://github.com/idealista/prometheus_server_role/issues/53) *[BUG] Change prometheus user shell path in /etc/passwd* @marcelogalmor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Changed
 ### Removed
 
+### Fixed
+- [#56](https://github.com/idealista/prometheus_server_role/issues/56) *Stop using reload handler in favour of the restart one* @caldito
 ### Added
 - [#53](https://github.com/idealista/prometheus_server_role/issues/53) *[BUG] Change prometheus user shell path in /etc/passwd* @marcelogalmor
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,9 +59,6 @@ prometheus_external_hostname: "{{ ansible_nodename }}"
 
 prometheus_enable_remote_shutdown: 'false'
 
-# Handlers
-prometheus_reload_timeout: 60  # In seconds
-
 # Commands
 prometheus_promtool_cmd_separator: "{{ '-' if prometheus_version is version('2.0', operator='lt', strict=True) else ' ' }}"
 prometheus_promtool_check_rules: "check{{ prometheus_promtool_cmd_separator }}rules"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: reload prometheus
-  uri:
-    url: "http://localhost:{{ prometheus_port }}/-/reload"
-    method: "POST"
-    timeout: "{{ prometheus_reload_timeout }}"
 
 - name: restart prometheus
   systemd:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -43,7 +43,7 @@
     owner: "{{ prometheus_user }}"
     group: "{{ prometheus_group }}"
     mode: 0640
-  notify: reload prometheus
+  notify: restart prometheus
   loop: "{{ tmp_rules.files }}"
 
 - name: PROMETHEUS | Set new rules var


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change
The reload handler is no longer used because it does not work properly in some installations. Now the restart handler will be the only one used.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits
We do not use a handler which sometimes does not work.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
Little downtime when restarting, but the restart handler was used anyways.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
#56 
<!-- Enter any applicable Issues here -->
